### PR TITLE
MAINT: add link to complete numpy html manual on docs.scipy.org front pa...

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -23,8 +23,10 @@ Welcome! This is the documentation for Numpy and Scipy.
 
   <table class="contentstable" align="center"><tr>
     <td width="50%">
+      <p class="biglink"><a class="biglink" href="numpy/">Complete Numpy Manual</a><br/>
+        <span><a href="numpy/numpy-html-1.9.1.zip">[HTML+zip]</a>
+      </p>
       <p class="biglink"><a class="biglink" href="numpy/reference/">Numpy Reference Guide</a><br/>
-        <span><a href="numpy/numpy-html-1.9.1.zip">[HTML+zip]</a>,
           <a href="numpy/numpy-ref-1.9.1.pdf">[PDF]</a></span>
       </p>
       <p class="biglink"><a class="biglink" href="numpy/user/">Numpy User Guide (DRAFT)</a><br/>


### PR DESCRIPTION
...ge

That contains NEPs, ToC, license, etc. Is already online at
http://docs.scipy.org/doc/numpy/ but there's no link to it.

The html+zip links do download this complete manual, not the refguide.
The pdf links are for refguide/userguide only.
