### PR TITLE
MAINT: fix top "numpy developer guide" link

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -11,7 +11,7 @@ Welcome! This is the documentation for Numpy and Scipy.
 
   <table class="contentstable" align="center"><tr>
     <td width="50%">
-      <p class="biglink"><a class="biglink" href="numpy-dev/dev/">Numpy developer guide</a><br/>
+      <p class="biglink"><a class="biglink" href="numpy/dev/">Numpy developer guide</a><br/>
       <p class="biglink"><a class="biglink" href="scipy-dev/reference/hacking.html">Scipy developer guide</a><br/>
       </p>
     </td></tr>


### PR DESCRIPTION
there must have been a symbolic link at some point, or numpy changed its directory structure. In any case this fixes the bad link