### PR TITLE
Update to latest 1.14.x point release (1.14.5)

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -28,13 +28,13 @@ Welcome! This is the documentation for Numpy and Scipy.
   <table class="contentstable" align="center"><tr>
     <td width="50%">
       <p class="biglink"><a class="biglink" href="numpy/">Complete Numpy Manual</a><br/>
-        <span><a href="numpy/numpy-html-1.14.2.zip">[HTML+zip]</a></span>
+        <span><a href="numpy/numpy-html-1.14.5.zip">[HTML+zip]</a></span>
       </p>
       <p class="biglink"><a class="biglink" href="numpy/reference/">Numpy Reference Guide</a><br/>
-        <span><a href="numpy/numpy-ref-1.14.2.pdf">[PDF]</a></span>
+        <span><a href="numpy/numpy-ref-1.14.5.pdf">[PDF]</a></span>
       </p>
       <p class="biglink"><a class="biglink" href="numpy/user/">Numpy User Guide</a><br/>
-        <span><a href="numpy/numpy-user-1.14.2.pdf">[PDF]</a></span>
+        <span><a href="numpy/numpy-user-1.14.5.pdf">[PDF]</a></span>
       </p>
       <p class="biglink"><a class="biglink" href="numpy/f2py/">F2Py Guide</a><br/>
       </p>
@@ -58,12 +58,12 @@ Welcome! This is the documentation for Numpy and Scipy.
       <p><a href="https://www.numpy.org/devdocs/user/" class="extlink">
          Numpy (development version) User Guide</a>
       </p>
-      <p><a href="numpy-1.14.2/reference/">Numpy 1.14.2 Reference Guide</a>,
-        <span><a href="numpy-1.14.2/numpy-html-1.14.2.zip">[HTML+zip]</a>,
-          <a href="numpy-1.14.2/numpy-ref-1.14.2.pdf">[PDF]</a></span>
+      <p><a href="numpy-1.14.5/reference/">Numpy 1.14.5 Reference Guide</a>,
+        <span><a href="numpy-1.14.5/numpy-html-1.14.5.zip">[HTML+zip]</a>,
+          <a href="numpy-1.14.5/numpy-ref-1.14.5.pdf">[PDF]</a></span>
       </p>
-      <p><a href="numpy-1.14.2/user/">Numpy 1.14.2 User Guide</a>,
-        <span><a href="numpy-1.14.2/numpy-user-1.14.2.pdf">[PDF]</a></span>
+      <p><a href="numpy-1.14.5/user/">Numpy 1.14.5 User Guide</a>,
+        <span><a href="numpy-1.14.5/numpy-user-1.14.5.pdf">[PDF]</a></span>
       </p>
       <p><a href="numpy-1.14.1/reference/">Numpy 1.14.1 Reference Guide</a>,
         <span><a href="numpy-1.14.1/numpy-html-1.14.1.zip">[HTML+zip]</a>,


### PR DESCRIPTION
Replace 1.14.2 links with 1.14.5 to not clutter up
the front page that much.  Files for 1.14.2 left in place for now.