### PR TITLE
update for NumPy 1.15.1

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -36,7 +36,7 @@ html_sidebars = {
 }
 
 html_title = "Numpy and Scipy documentation"
-html_favicon = 'favicon.ico'
+#html_favicon = 'favicon.ico'
 html_static_path = ['_static']
 
 html_use_modindex = False

--- a/index.rst
+++ b/index.rst
@@ -28,13 +28,13 @@ Welcome! This is the documentation for Numpy and Scipy.
   <table class="contentstable" align="center"><tr>
     <td width="50%">
       <p class="biglink"><a class="biglink" href="numpy/">Complete Numpy Manual</a><br/>
-        <span><a href="numpy/numpy-html-1.15.0.zip">[HTML+zip]</a></span>
+        <span><a href="numpy/numpy-html-1.15.1.zip">[HTML+zip]</a></span>
       </p>
       <p class="biglink"><a class="biglink" href="numpy/reference/">Numpy Reference Guide</a><br/>
-        <span><a href="numpy/numpy-ref-1.15.0.pdf">[PDF]</a></span>
+        <span><a href="numpy/numpy-ref-1.15.1.pdf">[PDF]</a></span>
       </p>
       <p class="biglink"><a class="biglink" href="numpy/user/">Numpy User Guide</a><br/>
-        <span><a href="numpy/numpy-user-1.15.0.pdf">[PDF]</a></span>
+        <span><a href="numpy/numpy-user-1.15.1.pdf">[PDF]</a></span>
       </p>
       <p class="biglink"><a class="biglink" href="numpy/f2py/">F2Py Guide</a><br/>
       </p>
@@ -57,6 +57,13 @@ Welcome! This is the documentation for Numpy and Scipy.
       </p>
       <p><a href="https://www.numpy.org/devdocs/user/" class="extlink">
          Numpy (development version) User Guide</a>
+      </p>
+      <p><a href="numpy-1.15.1/reference/">Numpy 1.15.1 Reference Guide</a>,
+        <span><a href="numpy-1.15.1/numpy-html-1.15.1.zip">[HTML+zip]</a>,
+          <a href="numpy-1.15.1/numpy-ref-1.15.1.pdf">[PDF]</a></span>
+      </p>
+      <p><a href="numpy-1.15.1/user/">Numpy 1.15.1 User Guide</a>,
+        <span><a href="numpy-1.15.1/numpy-user-1.15.1.pdf">[PDF]</a></span>
       </p>
       <p><a href="numpy-1.15.0/reference/">Numpy 1.15.0 Reference Guide</a>,
         <span><a href="numpy-1.15.0/numpy-html-1.15.0.zip">[HTML+zip]</a>,


### PR DESCRIPTION
also silence a warning about `favicon.ico` missing.