### PR TITLE
Add SciPy 1.3.0

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -39,8 +39,8 @@ Welcome! This is the documentation for Numpy and Scipy.
       <p class="biglink"><a class="biglink" href="numpy/f2py/">F2Py Guide</a><br/>
       </p>
       <p class="biglink"><a class="biglink" href="scipy/reference/">Scipy Reference Guide</a><br/>
-        <span><a href="scipy/scipy-html-1.2.1.zip">[HTML+zip]</a>,
-          <a href="scipy/scipy-ref-1.2.1.pdf">[PDF]</a></span>
+        <span><a href="scipy/scipy-html-1.3.0.zip">[HTML+zip]</a>,
+          <a href="scipy/scipy-ref-1.3.0.pdf">[PDF]</a></span>
       </p>
     </td></tr>
   </table>
@@ -239,6 +239,10 @@ Welcome! This is the documentation for Numpy and Scipy.
    <li class="span6">
    <div>
       <p><a href="scipy-dev/reference/">Scipy (development version) Reference Guide</a>
+      </p>
+      <p><a href="scipy-1.3.0/reference/">Scipy 1.3.0 Reference Guide</a>,
+        <span><a href="scipy-1.3.0/scipy-html-1.3.0.zip">[HTML+zip]</a>,
+          <a href="scipy-1.3.0/scipy-ref-1.3.0.pdf">[PDF]</a></span>
       </p>
       <p><a href="scipy-1.2.1/reference/">Scipy 1.2.1 Reference Guide</a>,
         <span><a href="scipy-1.2.1/scipy-html-1.2.1.zip">[HTML+zip]</a>,


### PR DESCRIPTION
Add SciPy 1.3.0

I checked the docs & uploaded to server. They looked "ok," though I noted that PDF formatting isn't stunning. Some things looked a little different to me on the html side after upload vs. the local built html, too.

For example, spacing here: https://docs.scipy.org/doc/scipy/reference/spatial.html#module-scipy.spatial
Attributes listing here (scroll to bottom): https://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.ConvexHull.html#scipy.spatial.ConvexHull

But the local version looked a little cleaner with the colons between attributes and stuff after:
![image](https://user-images.githubusercontent.com/7903078/57958322-5e1e4800-78b4-11e9-8e02-94ef4f663503.png)
