### PR TITLE
Add versionwarning.js which docs can include

### DIFF
--- a/_static/versionwarning.js_t
+++ b/_static/versionwarning.js_t
@@ -1,0 +1,57 @@
+/* -*- js -*-
+ * versionwarning.js
+ *
+ * Display a warning box for obsolete doc versions, and add
+ * <link rel=canonical> to lead search engines to the right place.
+ *
+ * Docs can include this in any script via
+ *
+ * $.getScript("/doc/_static/versionwarning.js");
+ *
+ */
+
+$(document).ready(function() {
+    const latestStable = {
+        "scipy": "{{ SCIPY_LATEST_VERSION }}",
+        "numpy": "{{ NUMPY_LATEST_VERSION }}"
+    };
+    const names = {
+        "scipy": "SciPy",
+        "numpy": "NumPy"
+    };
+    const canonicalPrefix = {
+        "scipy": "https://docs.scipy.org/doc/scipy",
+        "numpy": "https://numpy.org/doc/stable"
+    };
+    const latestUrl = {
+        "scipy": "https://docs.scipy.org/doc/scipy/reference/",
+        "numpy": "https://numpy.org/doc/stable/"
+    };
+
+    const showWarning = (msg) => {
+        $('.body').prepend(
+            '<p style="padding: 1em; border: 1px solid red; background: pink;" class="versionwarning">'
+                + msg + '</p>');
+    };
+    const addCanonicalRel = (href) => {
+        $('head').append(
+            '<link rel="canonical" href="' + href + '"/>'
+        );
+    };
+
+    const pathPattern = /^\/doc\/(scipy|numpy)-([0-9.]+)(.*)/;
+    const m = location.pathname.match(pathPattern);
+
+    if (m !== null && m[2] != latestStable[m[1]]) {
+        if ($('.versionwarning').length > 0) {
+            return;
+        }
+
+        const canonicalUrl = canonicalPrefix[m[1]] + m[3];
+        showWarning('This is documentation for an old release of ' +
+                    names[m[1]] + ' (version ' + m[2] + '). Try the ' +
+                    '<a href="' + latestUrl[m[1]] + '">latest stable ' +
+                    'release</a> (version ' + latestStable[m[1]] + ').');
+        addCanonicalRel(canonicalUrl);
+    }
+});

--- a/_static/versionwarning.js_t
+++ b/_static/versionwarning.js_t
@@ -49,9 +49,10 @@ $(document).ready(function() {
 
         const canonicalUrl = canonicalPrefix[m[1]] + m[3];
         showWarning('This is documentation for an old release of ' +
-                    names[m[1]] + ' (version ' + m[2] + '). Try the ' +
-                    '<a href="' + latestUrl[m[1]] + '">latest stable ' +
-                    'release</a> (version ' + latestStable[m[1]] + ').');
+                    names[m[1]] + ' (version ' + m[2] + '). Read <a href="'
+                    + canonicalUrl + '">this page</a> in the ' +
+                    '<a href="' + latestUrl[m[1]] + '">documentation of the '
+                    + 'latest stable release</a> (version ' + latestStable[m[1]] + ').');
         addCanonicalRel(canonicalUrl);
     }
 });

--- a/conf.py
+++ b/conf.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 
 import os
+import re
+import pkg_resources
 from datetime import date
 
 # -- General configuration -----------------------------------------------------
@@ -19,6 +21,15 @@ version = ''
 release = ''
 pygments_style = 'sphinx'
 
+# -- Parse index.rst for _static/versionwarnings.js ----------------------------
+
+with open('index.rst', 'r') as f:
+    index_text = f.read()
+
+scipy_versions = set(re.findall('scipy-([0-9.]{3,})', index_text))
+scipy_latest_version = str(max(pkg_resources.parse_version(x) for x in scipy_versions))
+numpy_latest_version = '&gt; 1.17'
+
 # -- Options for HTML output ---------------------------------------------------
 
 html_theme_path = [os.path.join('scipy-sphinx-theme', '_theme')]
@@ -33,6 +44,11 @@ html_theme_options = {
 }
 html_sidebars = {
     'index': ['sitenav.html', 'searchbox.html'],
+}
+
+html_context = {
+    'SCIPY_LATEST_VERSION': scipy_latest_version,
+    'NUMPY_LATEST_VERSION': numpy_latest_version,
 }
 
 html_title = "Numpy and Scipy documentation"


### PR DESCRIPTION
Add a versionwarning.js that docs on this site can include to show warnings about reading documentation of obsolete software versions.

The latest version numbers are scraped from index.rst and substituted to the .js template, so they should stay up-to-date automatically when this site is updated.

See https://github.com/scipy/scipy/issues/12166 --- the approach here is similar to what scikit-learn does, but maybe a bit more automated.

The added blurb looks like this:

![kuva](https://user-images.githubusercontent.com/35046/82384379-4e819400-9a1f-11ea-9ca6-7d4fa1364c7b.png)
