### PR TITLE
versionwarning: check links with AJAX, to not show non-working links

### DIFF
--- a/_static/versionwarning.js_t
+++ b/_static/versionwarning.js_t
@@ -48,11 +48,33 @@ $(document).ready(function() {
         }
 
         const canonicalUrl = canonicalPrefix[m[1]] + m[3];
-        showWarning('This is documentation for an old release of ' +
-                    names[m[1]] + ' (version ' + m[2] + '). Read <a href="'
-                    + canonicalUrl + '">this page</a> in the ' +
-                    '<a href="' + latestUrl[m[1]] + '">documentation of the '
+
+        // Generate an URL for searching this page in stable docs, in
+        // case the canonical URL is not valid
+        let searchWords = document.title.replace(/—[^—]*$/, '').trim();
+        if (!searchWords) {
+            searchWords = document.title.trim();
+        }
+        const searchUrl = latestUrl[m[1]] + "search.html?q=" + encodeURI(searchWords);
+
+        showWarning('This is documentation for an old release of '
+                    + names[m[1]] + ' (version ' + m[2] + '). '
+                    + '<span class="versionwarning-readlink">Read <a href="'
+                    + canonicalUrl + '">this page</a></span> '
+                    + '<span class="versionwarning-searchlink" style="display: none;">Search for <a href="'
+                    + searchUrl + '">this page</a></span>'
+                    + ' in the <a href="' + latestUrl[m[1]] + '">documentation of the '
                     + 'latest stable release</a> (version ' + latestStable[m[1]] + ').');
         addCanonicalRel(canonicalUrl);
+
+        // Check if the canonical page actually exists, and if not,
+        // replace the direct link with a link to the search page
+        $.ajax({
+            url: canonicalUrl,
+            cache: true
+        }).fail(function (jqXHR, textStatus) {
+            $('.versionwarning-readlink').attr('style', 'display: none;');
+            $('.versionwarning-searchlink').attr('style', 'display: inline;');
+        });
     }
 });


### PR DESCRIPTION
For non-working links, link to the search box of the new docs instead.

<s>This results to Numpy docs always showing search box as they are on a
different site, so cross-origin policy prevents ajax checking those.

I.e., numpy.org would need to add `Access-Control-Allow-Origin: https://docs.scipy.org` (or some such [CORS header](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing)) if they want the direct links.</s>

**EDIT** Actually, it seems to just work for Numpy when deployed. Maybe I
had some issue in local testing.

Avoids confusing people (see https://github.com/scipy/docs.scipy.org/pull/38#issuecomment-647080374)