### PR TITLE
versionwarning: set canonical always, handle known Numpy moves

### DIFF
--- a/_static/versionwarning.js_t
+++ b/_static/versionwarning.js_t
@@ -11,6 +11,7 @@
  */
 
 $(document).ready(function() {
+    const pathPattern = /^\/doc\/(scipy|numpy)-([0-9.]+)(.*)/;
     const latestStable = {
         "scipy": "{{ SCIPY_LATEST_VERSION }}",
         "numpy": "{{ NUMPY_LATEST_VERSION }}"
@@ -19,9 +20,16 @@ $(document).ready(function() {
         "scipy": "SciPy",
         "numpy": "NumPy"
     };
-    const canonicalPrefix = {
-        "scipy": "https://docs.scipy.org/doc/scipy",
-        "numpy": "https://numpy.org/doc/stable"
+    const getCanonicalUrl = (name, path) => {
+        if (name == "numpy") {
+            // Fixup Numpy URL for some pages known to be moved
+            path = path.replace("/reference/generated/numpy.random.",
+                                "/reference/random/generated/numpy.random.");
+            return "https://numpy.org/doc/stable" + path;
+        }
+        else {
+            return "https://docs.scipy.org/doc/scipy" + path;
+        }
     };
     const latestUrl = {
         "scipy": "https://docs.scipy.org/doc/scipy/reference/",
@@ -39,16 +47,14 @@ $(document).ready(function() {
         );
     };
 
-    const pathPattern = /^\/doc\/(scipy|numpy)-([0-9.]+)(.*)/;
     const m = location.pathname.match(pathPattern);
-
     if (m !== null) {
         if ($('.versionwarning').length > 0) {
             return;
         }
 
         // Always add canonical rel tag
-        const canonicalUrl = canonicalPrefix[m[1]] + m[3];
+        const canonicalUrl = getCanonicalUrl(m[1], m[3]);
         addCanonicalRel(canonicalUrl);
 
         if (m[2] != latestStable[m[1]]) {

--- a/_static/versionwarning.js_t
+++ b/_static/versionwarning.js_t
@@ -42,39 +42,44 @@ $(document).ready(function() {
     const pathPattern = /^\/doc\/(scipy|numpy)-([0-9.]+)(.*)/;
     const m = location.pathname.match(pathPattern);
 
-    if (m !== null && m[2] != latestStable[m[1]]) {
+    if (m !== null) {
         if ($('.versionwarning').length > 0) {
             return;
         }
 
+        // Always add canonical rel tag
         const canonicalUrl = canonicalPrefix[m[1]] + m[3];
-
-        // Generate an URL for searching this page in stable docs, in
-        // case the canonical URL is not valid
-        let searchWords = document.title.replace(/—[^—]*$/, '').trim();
-        if (!searchWords) {
-            searchWords = document.title.trim();
-        }
-        const searchUrl = latestUrl[m[1]] + "search.html?q=" + encodeURI(searchWords);
-
-        showWarning('This is documentation for an old release of '
-                    + names[m[1]] + ' (version ' + m[2] + '). '
-                    + '<span class="versionwarning-readlink">Read <a href="'
-                    + canonicalUrl + '">this page</a></span> '
-                    + '<span class="versionwarning-searchlink" style="display: none;">Search for <a href="'
-                    + searchUrl + '">this page</a></span>'
-                    + ' in the <a href="' + latestUrl[m[1]] + '">documentation of the '
-                    + 'latest stable release</a> (version ' + latestStable[m[1]] + ').');
         addCanonicalRel(canonicalUrl);
 
-        // Check if the canonical page actually exists, and if not,
-        // replace the direct link with a link to the search page
-        $.ajax({
-            url: canonicalUrl,
-            cache: true
-        }).fail(function (jqXHR, textStatus) {
-            $('.versionwarning-readlink').attr('style', 'display: none;');
-            $('.versionwarning-searchlink').attr('style', 'display: inline;');
-        });
+        if (m[2] != latestStable[m[1]]) {
+            // For obsolete versions, show a warning
+
+            // Generate an URL for searching this page in stable docs, in
+            // case the canonical URL is not valid
+            let searchWords = document.title.replace(/—[^—]*$/, '').trim();
+            if (!searchWords) {
+                searchWords = document.title.trim();
+            }
+            const searchUrl = latestUrl[m[1]] + "search.html?q=" + encodeURI(searchWords);
+
+            showWarning('This is documentation for an old release of '
+                        + names[m[1]] + ' (version ' + m[2] + '). '
+                        + '<span class="versionwarning-readlink">Read <a href="'
+                        + canonicalUrl + '">this page</a></span> '
+                        + '<span class="versionwarning-searchlink" style="display: none;">Search for <a href="'
+                        + searchUrl + '">this page</a></span>'
+                        + ' in the <a href="' + latestUrl[m[1]] + '">documentation of the '
+                        + 'latest stable release</a> (version ' + latestStable[m[1]] + ').');
+
+            // Check if the canonical page actually exists, and if not,
+            // replace the direct link with a link to the search page
+            $.ajax({
+                url: canonicalUrl,
+                cache: true
+            }).fail(function (jqXHR, textStatus) {
+                $('.versionwarning-readlink').attr('style', 'display: none;');
+                $('.versionwarning-searchlink').attr('style', 'display: inline;');
+            });
+        }
     }
 });


### PR DESCRIPTION
We want the canonical tag also on the latest scipy-x.y.z page, because it will also go out of date at some point.

Add special handling for Numpy doc pages that are known to be moved.