### PR TITLE
FIX: broken link to SciPy devdocs

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -12,7 +12,7 @@ Welcome! This is the documentation for Numpy and Scipy.
   <table class="contentstable" align="center"><tr>
     <td width="50%">
       <p class="biglink"><a class="biglink" href="numpy/dev/">Numpy developer guide</a><br/>
-      <p class="biglink"><a class="biglink" href="scipy-dev/dev/">Scipy developer guide</a><br/>
+      <p class="biglink"><a class="biglink" href="scipy-dev/reference/dev/">Scipy developer guide</a><br/>
       </p>
     </td></tr>
   </table>

--- a/index.rst
+++ b/index.rst
@@ -12,7 +12,7 @@ Welcome! This is the documentation for Numpy and Scipy.
   <table class="contentstable" align="center"><tr>
     <td width="50%">
       <p class="biglink"><a class="biglink" href="numpy/dev/">Numpy developer guide</a><br/>
-      <p class="biglink"><a class="biglink" href="scipy-dev/reference/hacking.html">Scipy developer guide</a><br/>
+      <p class="biglink"><a class="biglink" href="scipy-dev/dev/">Scipy developer guide</a><br/>
       </p>
     </td></tr>
   </table>


### PR DESCRIPTION
Since the refactoring the url of the developer doc of SciPy changed.

I am just not sure about the url path as I did not manage to properly build it locally.