### PR TITLE
versionwarning: fixup for the new sphinx theme

### DIFF
--- a/_static/versionwarning.js_t
+++ b/_static/versionwarning.js_t
@@ -37,7 +37,7 @@ $(document).ready(function() {
     };
 
     const showWarning = (msg) => {
-        $('.body').prepend(
+        $('.body, main').prepend(
             '<p style="padding: 1em; border: 1px solid red; background: pink;" class="versionwarning">'
                 + msg + '</p>');
     };


### PR DESCRIPTION
The new sphinx theme has main instead of div.body, so the warning should go also there.