### PR TITLE
Fix links to SciPy 1.8.0/1.8.1 docs

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -38,7 +38,7 @@ Welcome! This is the documentation for Numpy and Scipy.
       </p>
       <p class="biglink"><a class="biglink" href="numpy/f2py/">F2Py Guide</a><br/>
       </p>
-      <p class="biglink"><a class="biglink" href="scipy/reference/">Scipy Reference Guide</a><br/>
+      <p class="biglink"><a class="biglink" href="scipy/">SciPy Documentation</a><br/>
         <span><a href="scipy/scipy-html-1.8.1.zip">[HTML+zip]</a>,
           <a href="scipy/scipy-ref-1.8.1.pdf">[PDF]</a></span>
       </p>
@@ -249,11 +249,11 @@ Welcome! This is the documentation for Numpy and Scipy.
    <div>
       <p><a href="scipy-dev/reference/">Scipy (development version) Reference Guide</a>
       </p>
-      <p><a href="scipy-1.8.1/reference/">Scipy 1.8.1 Reference Guide</a>,
+      <p><a href="scipy-1.8.1/">SciPy 1.8.1 Documentation</a>,
         <span><a href="scipy-1.8.1/scipy-html-1.8.1.zip">[HTML+zip]</a>,
           <a href="scipy-1.8.1/scipy-ref-1.8.1.pdf">[PDF]</a></span>
       </p>
-      <p><a href="scipy-1.8.0/reference/">Scipy 1.8.0 Reference Guide</a>,
+      <p><a href="scipy-1.8.0/">SciPy 1.8.0 Documentation</a>,
         <span><a href="scipy-1.8.0/scipy-html-1.8.0.zip">[HTML+zip]</a>,
           <a href="scipy-1.8.0/scipy-ref-1.8.0.pdf">[PDF]</a></span>
       </p>


### PR DESCRIPTION
Follow-up to gh-63