### PR TITLE
Add SciPy 1.9.0

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -39,8 +39,7 @@ Welcome! This is the documentation for Numpy and Scipy.
       <p class="biglink"><a class="biglink" href="numpy/f2py/">F2Py Guide</a><br/>
       </p>
       <p class="biglink"><a class="biglink" href="scipy/">SciPy Documentation</a><br/>
-        <span><a href="scipy/scipy-html-1.8.1.zip">[HTML+zip]</a>,
-          <a href="scipy/scipy-ref-1.8.1.pdf">[PDF]</a></span>
+        <span><a href="scipy/scipy-html-1.9.0.zip">[HTML+zip]</a></span>
       </p>
     </td></tr>
   </table>
@@ -248,6 +247,9 @@ Welcome! This is the documentation for Numpy and Scipy.
    <li class="span6">
    <div>
       <p><a href="scipy-dev/reference/">Scipy (development version) Reference Guide</a>
+      </p>
+      <p><a href="scipy-1.9.0/">SciPy 1.9.0 Documentation</a>,
+        <span><a href="scipy-1.9.0/scipy-html-1.9.0.zip">[HTML+zip]</a></span>
       </p>
       <p><a href="scipy-1.8.1/">SciPy 1.8.1 Documentation</a>,
         <span><a href="scipy-1.8.1/scipy-html-1.8.1.zip">[HTML+zip]</a>,


### PR DESCRIPTION
Add SciPy `1.9.0`

Caution, things keep changing with our docs process so this is a bit different than previously, and links/intersphinx connections have had problems on almost every release in recent memory:
- I believe we no longer generate/upload PDF docs, so this diff is a bit different than in previous releases
- I think we've switched away from needing to edit `.htaccess` on the docs server manually, though it is confusing:
  - https://github.com/tylerjereddy/htaccess_backup/pull/2#discussion_r878010372

This morning I already did:
- `make dist`
- `make upload USERNAME=treddy RELEASE=1.9.0`