### PR TITLE
Fix broken link on searchUrl

### DIFF
--- a/_static/versionwarning.js_t
+++ b/_static/versionwarning.js_t
@@ -35,7 +35,6 @@ $(document).ready(function() {
         "scipy": "https://docs.scipy.org/doc/scipy/reference/",
         "numpy": "https://numpy.org/doc/stable/"
     };
-    const searchUrl = "https://docs.scipy.org/doc/scipy/search.html?q=" + encodeURI(searchWords);
 
     const showWarning = (msg) => {
         $('.body, main').prepend(
@@ -67,6 +66,7 @@ $(document).ready(function() {
             if (!searchWords) {
                 searchWords = document.title.trim();
             }
+            const searchUrl = "https://docs.scipy.org/doc/scipy/search.html?q=" + encodeURI(searchWords);
 
             showWarning('This is documentation for an old release of '
                         + names[m[1]] + ' (version ' + m[2] + '). '

--- a/_static/versionwarning.js_t
+++ b/_static/versionwarning.js_t
@@ -66,7 +66,7 @@ $(document).ready(function() {
             if (!searchWords) {
                 searchWords = document.title.trim();
             }
-            const searchUrl = latestUrl[m[1]] + "search.html?q=" + encodeURI(searchWords);
+            const searchUrl = "https://docs.scipy.org/doc/scipy/search.html?q=" + encodeURI(searchWords);
 
             showWarning('This is documentation for an old release of '
                         + names[m[1]] + ' (version ' + m[2] + '). '

--- a/_static/versionwarning.js_t
+++ b/_static/versionwarning.js_t
@@ -35,6 +35,7 @@ $(document).ready(function() {
         "scipy": "https://docs.scipy.org/doc/scipy/reference/",
         "numpy": "https://numpy.org/doc/stable/"
     };
+    const searchUrl = "https://docs.scipy.org/doc/scipy/search.html?q=" + encodeURI(searchWords);
 
     const showWarning = (msg) => {
         $('.body, main').prepend(
@@ -66,7 +67,6 @@ $(document).ready(function() {
             if (!searchWords) {
                 searchWords = document.title.trim();
             }
-            const searchUrl = "https://docs.scipy.org/doc/scipy/search.html?q=" + encodeURI(searchWords);
 
             showWarning('This is documentation for an old release of '
                         + names[m[1]] + ' (version ' + m[2] + '). '


### PR DESCRIPTION
In the warning about checking the documentation for an old release,

![image](https://user-images.githubusercontent.com/5776022/207868072-3820df27-49eb-4dc0-9a11-a9fee711c416.png)

_this page_ points to https://docs.scipy.org/doc/scipy/reference/search.html?q=(...), returning a 404 error. It should point to https://docs.scipy.org/doc/scipy/search.html?q=(...).

Maybe you'd like to fix it differently; please let me know.
