### PR TITLE
Add SciPy 1.13.0

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -39,7 +39,7 @@ Welcome! This is the documentation for Numpy and Scipy.
       <p class="biglink"><a class="biglink" href="numpy/f2py/">F2Py Guide</a><br/>
       </p>
       <p class="biglink"><a class="biglink" href="scipy/">SciPy Documentation</a><br/>
-        <span><a href="scipy/scipy-html-1.12.0.zip">[HTML+zip]</a></span>
+        <span><a href="scipy/scipy-html-1.13.0.zip">[HTML+zip]</a></span>
       </p>
     </td></tr>
   </table>
@@ -247,6 +247,9 @@ Welcome! This is the documentation for Numpy and Scipy.
    <li class="span6">
    <div>
       <p><a href="scipy-dev/reference/">Scipy (development version) Reference Guide</a>
+      </p>
+      <p><a href="scipy-1.13.0/">SciPy 1.13.0 Documentation</a>,
+        <span><a href="scipy-1.13.0/scipy-html-1.13.0.zip">[HTML+zip]</a></span>
       </p>
       <p><a href="scipy-1.12.0/">SciPy 1.12.0 Documentation</a>,
         <span><a href="scipy-1.12.0/scipy-html-1.12.0.zip">[HTML+zip]</a></span>


### PR DESCRIPTION
I just did `make dist` and `make upload` steps. I circumvented https://github.com/scipy/scipy/issues/20379 by using Python `3.11` instead of `3.9` in my base env, after completing the rest of the rel process.