### PR TITLE
Add SciPy 1.15.0

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -39,7 +39,7 @@ Welcome! This is the documentation for Numpy and Scipy.
       <p class="biglink"><a class="biglink" href="numpy/f2py/">F2Py Guide</a><br/>
       </p>
       <p class="biglink"><a class="biglink" href="scipy/">SciPy Documentation</a><br/>
-        <span><a href="scipy/scipy-html-1.14.0.zip">[HTML+zip]</a></span>
+        <span><a href="scipy/scipy-html-1.15.0.zip">[HTML+zip]</a></span>
       </p>
     </td></tr>
   </table>
@@ -247,6 +247,9 @@ Welcome! This is the documentation for Numpy and Scipy.
    <li class="span6">
    <div>
       <p><a href="scipy-dev/reference/">Scipy (development version) Reference Guide</a>
+      </p>
+      <p><a href="scipy-1.15.0/">SciPy 1.15.0 Documentation</a>,
+        <span><a href="scipy-1.15.0/scipy-html-1.15.0.zip">[HTML+zip]</a></span>
       </p>
       <p><a href="scipy-1.14.1/">SciPy 1.14.1 Documentation</a>,
         <span><a href="scipy-1.14.1/scipy-html-1.14.1.zip">[HTML+zip]</a></span>


### PR DESCRIPTION
* Add SciPy `1.15.0`. I just did `make dist` and `make upload` steps.

* Looks like I forgot to bump one of the versions for `1.14.1` last time at gh-91, but caught it this time.

Usually something weird happens with version switcher until the full update/sync is done with (we keep having that discussion in these PRs I think--anyway, it usually works out once things get merged/updated).