### PR TITLE
Add SciPy 1.16.0

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -39,7 +39,7 @@ Welcome! This is the documentation for Numpy and Scipy.
       <p class="biglink"><a class="biglink" href="numpy/f2py/">F2Py Guide</a><br/>
       </p>
       <p class="biglink"><a class="biglink" href="scipy/">SciPy Documentation</a><br/>
-        <span><a href="scipy/scipy-html-1.15.3.zip">[HTML+zip]</a></span>
+        <span><a href="scipy/scipy-html-1.16.0.zip">[HTML+zip]</a></span>
       </p>
     </td></tr>
   </table>
@@ -247,6 +247,9 @@ Welcome! This is the documentation for Numpy and Scipy.
    <li class="span6">
    <div>
       <p><a href="scipy-dev/reference/">Scipy (development version) Reference Guide</a>
+      </p>
+      <p><a href="scipy-1.16.0/">SciPy 1.16.0 Documentation</a>,
+        <span><a href="scipy-1.16.0/scipy-html-1.16.0.zip">[HTML+zip]</a></span>
       </p>
       <p><a href="scipy-1.15.3/">SciPy 1.15.3 Documentation</a>,
         <span><a href="scipy-1.15.3/scipy-html-1.15.3.zip">[HTML+zip]</a></span>


### PR DESCRIPTION
- Add SciPy `1.16.0`. I just did `make dist` and `make upload` steps.
- ~Note that the PR for adding `1.15.3` is [still open](https://github.com/scipy/docs.scipy.org/pull/96), so an argument could be made to try to include that here as well, though I haven't done that (if we merge this first, some changes will be needed over there, since `1.16.0` becomes the latest stable release).~
- As a reminder, version switcher shenanigans are likely until things are merged both here and in the main repo.