### PR TITLE
Add SciPy 1.18.0

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -39,7 +39,7 @@ Welcome! This is the documentation for Numpy and Scipy.
       <p class="biglink"><a class="biglink" href="numpy/f2py/">F2Py Guide</a><br/>
       </p>
       <p class="biglink"><a class="biglink" href="scipy/">SciPy Documentation</a><br/>
-        <span><a href="scipy/scipy-html-1.17.0.zip">[HTML+zip]</a></span>
+        <span><a href="scipy/scipy-html-1.18.0.zip">[HTML+zip]</a></span>
       </p>
     </td></tr>
   </table>
@@ -247,6 +247,9 @@ Welcome! This is the documentation for Numpy and Scipy.
    <li class="span6">
    <div>
       <p><a href="scipy-dev/reference/">Scipy (development version) Reference Guide</a>
+      </p>
+      <p><a href="scipy-1.18.0/">SciPy 1.18.0 Documentation</a>,
+        <span><a href="scipy-1.18.0/scipy-html-1.18.0.zip">[HTML+zip]</a></span>
       </p>
       <p><a href="scipy-1.17.0/">SciPy 1.17.0 Documentation</a>,
         <span><a href="scipy-1.17.0/scipy-html-1.17.0.zip">[HTML+zip]</a></span>


### PR DESCRIPTION
- Add SciPy `1.18.0`. I just did `make dist` and `make upload` steps from the release tag.
- As a reminder, version switcher shenanigans are likely until some things are merged both here and in the main repo.
- Another reminder -- we're only uploading docs here for `x`/`y` releases in `x.y.z` (not `z` anymore), to save on space/infra, etc., so this is the first docs upload in a bit.